### PR TITLE
Bugfix/verify boundary check

### DIFF
--- a/sjwt.go
+++ b/sjwt.go
@@ -53,6 +53,9 @@ func Parse(tokenStr string) (Claims, error) {
 // Verify will take in the token string and secret and identify the signature matches
 func Verify(tokenStr string, secret []byte) bool {
 	token := strings.Split(tokenStr, ".")
+	if len(token) != 3 {
+		return false
+	}
 	mac := hmac.New(sha256.New, secret)
 	mac.Write([]byte(fmt.Sprintf("%s.%s", token[0], token[1])))
 	sig, _ := base64.RawURLEncoding.DecodeString(token[2])

--- a/sjwt_test.go
+++ b/sjwt_test.go
@@ -82,3 +82,12 @@ func TestVerifyError(t *testing.T) {
 		t.Error("verification should have failed")
 	}
 }
+
+func TestVerifyInvalidJWTError(t *testing.T) {
+	jwt := "not_a_jwt"
+
+	verified := Verify(jwt, secretKey)
+	if verified {
+		t.Error("verification should have failed")
+	}
+}


### PR DESCRIPTION
Verify should have the same kind of boundary check as Parse does if we want to avoid Panic at runtime.
This PR add a test and fix to the Verify function.